### PR TITLE
fix: mitigation of reported vulnerabilities

### DIFF
--- a/src/htlc.cairo
+++ b/src/htlc.cairo
@@ -87,7 +87,7 @@ pub mod HTLC {
     /// SNIP-12 type hash of the `Initiate` message signed for
     /// `initiate_with_signature`.
     pub const INITIATE_TYPE_HASH: felt252 = selector!(
-        "\"Initiate\"(\"redeemer\":\"ContractAddress\",\"amount\":\"u256\",\"timelock\":\"u128\",\"secretHash\":\"u128*\",\"verifyingContract\":\"ContractAddress\")\"u256\"(\"low\":\"u128\",\"high\":\"u128\")",
+        "\"Initiate\"(\"redeemer\":\"ContractAddress\",\"amount\":\"u256\",\"timelock\":\"u128\",\"secretHash\":\"u128*\",\"verifyingContract\":\"ContractAddress\",\"valid_until\":\"u128\")\"u256\"(\"low\":\"u128\",\"high\":\"u128\")",
     );
     /// SNIP-12 type hash of `u256`, which is hashed as a nested struct of its `low`
     /// and `high` limbs.
@@ -293,19 +293,24 @@ pub mod HTLC {
             timelock: u128,
             amount: u256,
             secret_hash: [u128; 2],
+            valid_until: u128,
             signature: Array<felt252>,
         ) {
             self.safe_params(initiator, redeemer, timelock, amount);
+            let block_info = get_block_info().unbox();
+            assert!(block_info.block_number.into() < valid_until, "HTLC: Expired signature");
+
             let verifying_contract = get_contract_address();
-            let intiate = Initiate {
+            let initiate = Initiate {
                 redeemer,
                 amount,
                 timelock,
                 secretHash: secret_hash,
                 verifyingContract: verifying_contract,
+                valid_until
             };
             let chain_id = self.chain_id.read();
-            let message_hash = intiate.get_message_hash(chain_id, initiator);
+            let message_hash = initiate.get_message_hash(chain_id, initiator);
 
             let is_valid = ISRC6Dispatcher { contract_address: initiator }
                 .is_valid_signature(message_hash, signature);
@@ -376,7 +381,9 @@ pub mod HTLC {
                 .orders
                 .write(order_id, Order { fulfilled_at: block_info.block_number.into(), ..order });
 
-            self.token.read().transfer(order.redeemer, order.amount);
+            let transfer_result = self.token.read().transfer(order.redeemer, order.amount);
+            assert!(transfer_result, "ERC20: Transfer failed");
+
             self
                 .emit(
                     Event::Redeemed(Redeemed { order_id, secret_hash: secret_hash_u128, secret }),
@@ -393,14 +400,16 @@ pub mod HTLC {
             assert!(order.redeemer.is_non_zero(), "HTLC: order not initiated");
             assert!(order.fulfilled_at.is_zero(), "HTLC: order fulfilled");
 
-            let block_info = get_block_info().unbox();
-            let current_block = block_info.block_number;
+            let current_block: u128 = get_block_info().unbox().block_number.into();
             assert!(
-                (order.initiated_at + order.timelock) < current_block.into(),
+                (current_block - order.initiated_at) > order.timelock,
                 "HTLC: order not expired",
             );
             self.orders.write(order_id, Order { fulfilled_at: current_block.into(), ..order });
-            self.token.read().transfer(order.initiator, order.amount);
+
+            let transfer_result = self.token.read().transfer(order.initiator, order.amount);
+            assert!(transfer_result, "ERC20: Transfer failed");
+
             self.emit(Event::Refunded(Refunded { order_id }));
         }
 
@@ -414,6 +423,11 @@ pub mod HTLC {
             let order = self.orders.read(order_id);
             assert!(order.redeemer.is_non_zero(), "HTLC: order not initiated");
             assert!(order.fulfilled_at.is_zero(), "HTLC: order fulfilled");
+
+            let block_info = get_block_info().unbox();
+            self
+                .orders
+                .write(order_id, Order { fulfilled_at: block_info.block_number.into(), ..order });
 
             let caller = get_caller_address();
 
@@ -432,12 +446,8 @@ pub mod HTLC {
                 assert!(is_valid_signature, "HTLC: invalid redeemer signature");
             }
 
-            let block_info = get_block_info().unbox();
-            self
-                .orders
-                .write(order_id, Order { fulfilled_at: block_info.block_number.into(), ..order });
-
-            self.token.read().transfer(order.initiator, order.amount);
+            let transfer_result = self.token.read().transfer(order.initiator, order.amount);
+            assert!(transfer_result, "ERC20: Transfer failed");
 
             self.emit(Event::Refunded(Refunded { order_id }));
         }

--- a/src/interface.cairo
+++ b/src/interface.cairo
@@ -213,8 +213,8 @@ pub trait IHTLC<TContractState> {
     ///
     /// The signature is checked with SRC-6 `is_valid_signature` against the
     /// `Initiate` struct hash, which covers the redeemer, amount, timelock, secret
-    /// hash and this contract's address, so it cannot be replayed against a
-    /// different order or a different deployment.
+    /// hash, expiry and this contract's address, so it cannot be replayed against a
+    /// different order, a different deployment, or after `valid_until`.
     ///
     /// # Arguments
     ///
@@ -223,6 +223,8 @@ pub trait IHTLC<TContractState> {
     /// * `timelock` - Number of blocks after initiation before a refund is allowed.
     /// * `amount` - Amount of tokens to lock.
     /// * `secret_hash` - SHA-256 hash of the secret, as two big-endian `u128` limbs.
+    /// * `valid_until` - Block number after which the signature is no longer
+    ///   accepted.
     /// * `signature` - SNIP-12 signature over the `Initiate` message, produced by
     ///   `initiator`.
     ///
@@ -230,6 +232,7 @@ pub trait IHTLC<TContractState> {
     ///
     /// * If `initiator` or `redeemer` is the zero address.
     /// * If `timelock` or `amount` is zero.
+    /// * If the current block number is not less than `valid_until`.
     /// * If `signature` is not a valid signature by `initiator` over this order.
     /// * If `initiator` is the `redeemer`.
     /// * If an order with these exact parameters already exists.
@@ -240,7 +243,7 @@ pub trait IHTLC<TContractState> {
     /// ```
     /// htlc
     ///     .initiate_with_signature(
-    ///         initiator, redeemer, 100, 1000, secret_hash, signature,
+    ///         initiator, redeemer, 100, 1000, secret_hash, valid_until, signature,
     ///     );
     /// ```
     fn initiate_with_signature(
@@ -250,6 +253,7 @@ pub trait IHTLC<TContractState> {
         timelock: u128,
         amount: u256,
         secret_hash: [u128; 2],
+        valid_until: u128,
         signature: Array<felt252>,
     );
 

--- a/src/interface/struct_hash.cairo
+++ b/src/interface/struct_hash.cairo
@@ -16,7 +16,7 @@
 //! use starknet_htlc::interface::struct_hash::Initiate;
 //!
 //! let initiate = Initiate {
-//!     redeemer, amount, timelock, secretHash: secret_hash, verifyingContract,
+//!     redeemer, amount, timelock, secretHash: secret_hash, verifyingContract, valid_until,
 //! };
 //! let message_hash = initiate.get_message_hash(chain_id, initiator);
 //! ```
@@ -48,6 +48,8 @@ pub struct Initiate {
     pub secretHash: [u128; 2],
     /// Address of the HTLC contract the signature is valid for.
     pub verifyingContract: ContractAddress,
+    /// Block number at which signature expires
+    pub valid_until: u128
 }
 
 /// The message a redeemer signs to let an order be refunded before its timelock
@@ -88,6 +90,7 @@ pub impl StructHashInitiate of IStructHash<Initiate> {
         state = state.update_with(*self.timelock);
         state = state.update_with(self.secretHash.span().get_struct_hash());
         state = state.update_with(*self.verifyingContract);
+        state = state.update_with(*self.valid_until);
         state.finalize()
     }
 }


### PR DESCRIPTION
## Changes  
- Reentrancy in `initiate_with_signature` fixed  
- Added checks for ERC-20 transfer results  
- `valid_until` added to `initiate_with_signature` for signature expiry, preventing free-option attacks  
- Arithmetic overflow prevented in `refund` flow  